### PR TITLE
Fix availability check endpoint parameter name

### DIFF
--- a/OCTO API Specification.postman_collection.json
+++ b/OCTO API Specification.postman_collection.json
@@ -175,7 +175,7 @@
 								"availability"
 							]
 						},
-						"description": "This endpoint is slightly slower as it will return an object for each individual departure time (or day). You have to perform this step to retrieve an `availabilityId` in order to confirm a sale, so if you just want to use this endpoint and skip the calendar endpoint then that's perfectly ok.\n\nYou must pass in one of the following combinations of parameters for this endpoint:\n- `localDate`\n- `localeDateStart` and `localDateEnd`\n- `availabilityIds`"
+						"description": "This endpoint is slightly slower as it will return an object for each individual departure time (or day). You have to perform this step to retrieve an `availabilityId` in order to confirm a sale, so if you just want to use this endpoint and skip the calendar endpoint then that's perfectly ok.\n\nYou must pass in one of the following combinations of parameters for this endpoint:\n- `localDate`\n- `localDateStart` and `localDateEnd`\n- `availabilityIds`"
 					},
 					"response": [
 						{


### PR DESCRIPTION
In the specification it describes the parameter as 'localeDateStart' but the example shows 'localDateStart'